### PR TITLE
[Enhance] Separate reusable components on agree page

### DIFF
--- a/routes/signup.js
+++ b/routes/signup.js
@@ -2,7 +2,7 @@ var express = require('express');
 var router = express.Router();
 
 router.get('/agree', function(req, res, next) {
-  res.render('signup/agree', { title: '회원가입' });
+  res.render('signup/agree/index', { title: '회원가입' });
 });
 
 router.get('/phone', function(req, res, next) {

--- a/views/signup/agree/checkbox-item.pug
+++ b/views/signup/agree/checkbox-item.pug
@@ -1,0 +1,5 @@
+mixin checkbox-item({name, agreeRequired})
+      div.row   
+        input(type='checkbox' name=name id=name class=(agreeRequired? "agree-required" : ""))
+        label(for=name)= name + (agreeRequired? '' : '(선택)')
+        img.arrow(src='/images/arrow.png' alt='arrow')      

--- a/views/signup/agree/checkbox-list.pug
+++ b/views/signup/agree/checkbox-list.pug
@@ -1,0 +1,24 @@
+include ./checkbox-item
+
+div.row
+    input(type='checkbox' name='all-agree' id='all-agree')
+    label(for='all-agree')
+        strong= '전체동의'
++checkbox-item({
+    name: '배달의민족 이용약관 동의',
+    agreeRequired: true,
+})
++checkbox-item({
+    name: '전자금융거래 이용약관 동의',
+    agreeRequired: true,
+})
++checkbox-item({
+    name: '개인정보 수집이용 동의',
+    agreeRequired: true,
+})
++checkbox-item({
+    name: '개인정보 제3자 제공 동의',
+})
++checkbox-item({
+    name: '마케팅 정보 메일, SMS 수신 동의',
+})

--- a/views/signup/agree/header.pug
+++ b/views/signup/agree/header.pug
@@ -1,0 +1,4 @@
+header
+    a.back(href='/signin') 
+      img(src='/images/cancel.svg' alt='cancel')
+    h1.title= '회원가입'

--- a/views/signup/agree/index.pug
+++ b/views/signup/agree/index.pug
@@ -1,0 +1,15 @@
+extends ../../layout
+
+block head
+  link(rel='stylesheet', href='/stylesheets/signup/agree.css')
+  script(src="/javascripts/signup/agree.js", type="module", defer="defer") 
+
+block content
+  include ./header
+  h2
+    | 어서오세요 <br/>
+    | 약관동의가 필요해요
+  form
+    include ./checkbox-list      
+    include ./radio-list
+    a.next.disabled(href="/signup/phone")= '다음으로'

--- a/views/signup/agree/radio-item.pug
+++ b/views/signup/agree/radio-item.pug
@@ -1,0 +1,5 @@
+mixin radio-item({name, value, label, checked = false, imgSrc})
+      div.radio-wrapper
+        input(type="radio" name=name id=name value=value checked=checked)
+        label(for=name)= label
+        img.radio(src=imgSrc)      

--- a/views/signup/agree/radio-list.pug
+++ b/views/signup/agree/radio-list.pug
@@ -1,0 +1,15 @@
+include ./radio-item
+
++radio-item({
+    name: 'age-range',
+    value: 'over-14',
+    label: '만 14세 이상입니다.',
+    checked: true,
+    imgSrc: '/images/over.png'
+})
++radio-item({
+    name: 'age-range',
+    value: 'under-14',
+    label: '만 14세 미만입니다.',
+    imgSrc: '/images/under.png'
+})


### PR DESCRIPTION
## Description

회원가입 약관동의 페이지에서 반복되는 UI를 컴포넌트로 분리하고 재사용하여 리팩토링합니다.

## Related Issues

resolve #20 

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] Issue TODO finished
- [x] No Conflicts with the base branch
